### PR TITLE
Remove strong mode leftover

### DIFF
--- a/package.json
+++ b/package.json
@@ -20,8 +20,7 @@
   },
   "main": "index.js",
   "scripts": {
-    "test": "./node_modules/.bin/mocha tests/*.js && ./node_modules/.bin/eslint .",
-    "test-strong-mode": "node --strong-mode ./node_modules/.bin/_mocha tests/*.js"
+    "test": "./node_modules/.bin/mocha tests/*.js && ./node_modules/.bin/eslint ."
   },
   "dependencies": {
     "nan": "^2.14.0"


### PR DESCRIPTION
strong mode was an experimental JavaScript mode that was being tested by the V8 team in 2015 but did not survive.