### PR TITLE
Ensure node 8 test envs also have old Python <= 3.9

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -9,7 +9,14 @@ jobs:
     strategy:
       matrix:
         virtual-environment: ['ubuntu-latest', 'macos-latest', 'windows-2019']
-        node: [8, 10, 12, 14, 16, 18, 19]
+        node: [10, 12, 14, 16, 18, 19]
+        include:
+          - node: 8
+            virtual-environment: 'ubuntu-20.04'
+          - node: 8
+            virtual-environment: 'macos-11'
+          - node: 8
+            virtual-environment: 'windows-2019'
 
     runs-on: ${{ matrix.virtual-environment }}
 


### PR DESCRIPTION
Fix node 8 environments to:

- ubuntu-20.04
- macos-11
- windows 2019
