### PR TITLE
Added node 22 environment to GitHub Actions workflow

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -12,6 +12,10 @@ jobs:
         node: [12, 14, 16, 18, 20, 22]
         include:
           - virtual-environment: 'macos-latest'
+            node: 18
+          - virtual-environment: 'macos-latest'
+            node: 20
+          - virtual-environment: 'macos-latest'
             node: 22
 
     runs-on: ${{ matrix.virtual-environment }}

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -23,6 +23,7 @@ jobs:
 
     - name: Setup Python
       uses: actions/setup-python@v5 
+      run: pip install setuptools
 
     - name: Setup Node.js ${{ matrix.node }}
       uses: actions/setup-node@v4

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -23,6 +23,8 @@ jobs:
 
     - name: Setup Python
       uses: actions/setup-python@v5 
+
+    - name: Install setupools
       run: pip install setuptools
 
     - name: Setup Node.js ${{ matrix.node }}

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -12,8 +12,6 @@ jobs:
         node: [12, 14, 16, 18, 20, 22]
         include:
           - virtual-environment: 'macos-latest'
-            node: 16
-          - virtual-environment: 'macos-latest'
             node: 18
           - virtual-environment: 'macos-latest'
             node: 20

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -9,7 +9,7 @@ jobs:
     strategy:
       matrix:
         virtual-environment: ['ubuntu-latest', 'macos-latest', 'windows-2019']
-        node: [12, 14, 16, 18, 20, 21]
+        node: [12, 14, 16, 18, 20, 22]
 
     runs-on: ${{ matrix.virtual-environment }}
 

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -19,10 +19,10 @@ jobs:
       run: git config --global core.autocrlf false
 
     - name: Checkout
-      uses: actions/checkout@v3
+      uses: actions/checkout@v4
 
     - name: Setup Node.js ${{ matrix.node }}
-      uses: actions/setup-node@v3
+      uses: actions/setup-node@v4
       with:
         node-version: ${{ matrix.node }}
 

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -21,9 +21,11 @@ jobs:
     - name: Checkout
       uses: actions/checkout@v4
 
+    - name: Setup Python
+      uses: actions/setup-python@v5 
+
     - name: Setup Node.js ${{ matrix.node }}
       uses: actions/setup-node@v4
-      uses: actions/setup-python@v5
       with:
         node-version: ${{ matrix.node }}
 

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -8,7 +8,7 @@ jobs:
 
     strategy:
       matrix:
-        virtual-environment: ['ubuntu-latest', 'macos-14', 'windows-2019']
+        virtual-environment: ['ubuntu-latest', 'macos-13', 'windows-2019']
         node: [12, 14, 16, 18, 20, 22]
 
     runs-on: ${{ matrix.virtual-environment }}

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -8,7 +8,7 @@ jobs:
 
     strategy:
       matrix:
-        virtual-environment: ['ubuntu-latest', 'macos-13', 'windows-2019']
+        virtual-environment: ['ubuntu-latest', 'windows-2019']
         node: [12, 14, 16, 18, 20, 22]
 
     runs-on: ${{ matrix.virtual-environment }}
@@ -19,16 +19,10 @@ jobs:
       run: git config --global core.autocrlf false
 
     - name: Checkout
-      uses: actions/checkout@v4
-
-    - name: Setup Python
-      uses: actions/setup-python@v5 
-
-    - name: Install setupools
-      run: pip install setuptools
+      uses: actions/checkout@v3
 
     - name: Setup Node.js ${{ matrix.node }}
-      uses: actions/setup-node@v4
+      uses: actions/setup-node@v3
       with:
         node-version: ${{ matrix.node }}
 

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -8,7 +8,7 @@ jobs:
 
     strategy:
       matrix:
-        virtual-environment: ['ubuntu-latest', 'macos-latest', 'windows-2019']
+        virtual-environment: ['ubuntu-latest', 'macos-14', 'windows-2019']
         node: [12, 14, 16, 18, 20, 22]
 
     runs-on: ${{ matrix.virtual-environment }}

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -10,6 +10,9 @@ jobs:
       matrix:
         virtual-environment: ['ubuntu-latest', 'windows-2019']
         node: [12, 14, 16, 18, 20, 22]
+        include:
+          - virtual-environment: 'macos-latest'
+            node: 22
 
     runs-on: ${{ matrix.virtual-environment }}
 

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -23,6 +23,7 @@ jobs:
 
     - name: Setup Node.js ${{ matrix.node }}
       uses: actions/setup-node@v4
+      uses: actions/setup-python@v5
       with:
         node-version: ${{ matrix.node }}
 

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -12,6 +12,8 @@ jobs:
         node: [12, 14, 16, 18, 20, 22]
         include:
           - virtual-environment: 'macos-latest'
+            node: 16
+          - virtual-environment: 'macos-latest'
             node: 18
           - virtual-environment: 'macos-latest'
             node: 20


### PR DESCRIPTION
Updated GitHub Actions workflow:

- Upgraded to actions checkout@v4 and setup-node@v4
- Added Node.js 22 to test matrix
- Dropped EOL Node versions from autonatic testing on macos-latest
